### PR TITLE
feat: add json output option

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,14 +2,14 @@
 
 #### Add Output Format Option
 
-* [ ] Add CLI option `--format {human,json}` (default: `human`).
-* [ ] Modify `main()` and `print_uncovered_sections()` to dispatch based on format.
+* [x] Add CLI option `--format {human,json}` (default: `human`).
+* [x] Modify `main()` and `print_uncovered_sections()` to dispatch based on format.
 * [ ] Abstract uncovered data into a structured internal model before formatting.
 
 #### Implement JSON Output
 
 * [ ] Assess the proposed JSON schema in the appendix for suitability.
-* [ ] Write `print_json_output(uncovered_data: dict[Path, list[int]]) -> None`.
+* [x] Write `print_json_output(uncovered_data: dict[Path, list[int]]) -> None`.
 * [ ] Add `--context-lines=N` (optional): include source lines ±N around each uncovered section.
 * [ ] Validate generated JSON matches schema using a static schema or runtime validator.
 
@@ -18,8 +18,8 @@
 #### Machine-Friendliness
 
 * [x] add a --no-color flag
-* [ ] Remove all ANSI color codes and text styling from `json` mode.
-* [ ] Normalize all paths to POSIX-style (`/`) and resolve relative paths.
+* [x] Remove all ANSI color codes and text styling from `json` mode.
+* [x] Normalize all paths to POSIX-style (`/`) and resolve relative paths.
 
 #### Determinism and Consistency
 
@@ -67,7 +67,7 @@
 
 #### Add Format-Specific Tests
 
-* [ ] Add tests for `--format json` using `json.loads` and structural assertions.
+* [x] Add tests for `--format json` using `json.loads` and structural assertions.
 * [ ] Add round-trip validation: uncovered → JSON → parsed → == original.
 
 #### Ensure LLM Usability

--- a/src/showcov/core.py
+++ b/src/showcov/core.py
@@ -89,11 +89,11 @@ def determine_xml_file(xml_file: Namespace | None = None) -> Path:
         xml_file = xml_file.xml_file
 
     if xml_file:
-        return Path(xml_file)
+        return Path(xml_file).resolve()
 
     config_xml = get_config_xml_file()
     if config_xml:
-        return Path(config_xml)
+        return Path(config_xml).resolve()
 
     msg = "No coverage XML file specified or found in configuration."
     raise CoverageXMLNotFoundError(msg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,79 @@
+import json
+import sys
+from pathlib import Path
+
+from _pytest.capture import CaptureFixture
+from _pytest.monkeypatch import MonkeyPatch
+
+from showcov.cli import main, print_json_output
+
+
+def test_print_json_output(tmp_path: Path, capsys: CaptureFixture) -> None:
+    source_file = tmp_path / "dummy.py"
+    source_file.write_text("print('hi')\n")
+    uncovered = {source_file: [1, 2, 4]}
+    print_json_output(uncovered)
+    captured = capsys.readouterr().out
+    assert "\x1b" not in captured
+    data = json.loads(captured)
+    assert data["files"][0]["file"] == source_file.resolve().as_posix()
+    assert data["files"][0]["uncovered"] == [
+        {"start": 1, "end": 2},
+        {"start": 4, "end": 4},
+    ]
+
+
+def test_main_json_output(tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture) -> None:
+    source_file = tmp_path / "dummy.py"
+    source_file.write_text("print('hi')\n")
+    xml_content = f"""
+        <coverage>
+          <packages>
+            <package>
+              <classes>
+                <class filename=\"{source_file}\">
+                  <lines>
+                    <line number=\"1\" hits=\"0\"/>
+                  </lines>
+                </class>
+              </classes>
+            </package>
+          </packages>
+        </coverage>
+    """
+    xml_file = tmp_path / "coverage.xml"
+    xml_file.write_text(xml_content)
+    monkeypatch.setattr(sys, "argv", ["prog", str(xml_file), "--format", "json"])
+    main()
+    captured = capsys.readouterr().out
+    assert "\x1b" not in captured
+    data = json.loads(captured)
+    assert data["files"][0]["file"] == source_file.resolve().as_posix()
+    assert data["files"][0]["uncovered"] == [{"start": 1, "end": 1}]
+
+
+def test_main_json_output_no_uncovered(
+    tmp_path: Path, monkeypatch: MonkeyPatch, capsys: CaptureFixture
+) -> None:
+    xml_content = """
+        <coverage>
+          <packages>
+            <package>
+              <classes>
+                <class filename=\"dummy.py\">
+                  <lines>
+                    <line number=\"1\" hits=\"1\"/>
+                  </lines>
+                </class>
+              </classes>
+            </package>
+          </packages>
+        </coverage>
+    """
+    xml_file = tmp_path / "coverage.xml"
+    xml_file.write_text(xml_content)
+    monkeypatch.setattr(sys, "argv", ["prog", str(xml_file), "--format", "json"])
+    main()
+    captured = capsys.readouterr().out
+    data = json.loads(captured)
+    assert data["files"] == []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,14 +71,14 @@ def test_get_config_xml_file_pyproject(monkeypatch: MonkeyPatch, tmp_path: Path)
 def test_determine_xml_file_argument(monkeypatch: MonkeyPatch) -> None:
     test_args = ["prog", "coverage.xml"]
     monkeypatch.setattr(sys, "argv", test_args)
-    assert determine_xml_file(argparse.Namespace(xml_file="coverage.xml")) == Path("coverage.xml")
+    assert determine_xml_file(argparse.Namespace(xml_file="coverage.xml")) == Path("coverage.xml").resolve()
 
 
 def test_determine_xml_file_from_config(monkeypatch: MonkeyPatch) -> None:
     test_args = ["prog"]
     monkeypatch.setattr(sys, "argv", test_args)
     monkeypatch.setattr("showcov.core.get_config_xml_file", lambda: "coverage.xml")
-    assert determine_xml_file(argparse.Namespace(xml_file="coverage.xml")) == Path("coverage.xml")
+    assert determine_xml_file(argparse.Namespace(xml_file="coverage.xml")) == Path("coverage.xml").resolve()
 
 
 def test_determine_xml_file_no_args(monkeypatch: MonkeyPatch) -> None:
@@ -97,6 +97,7 @@ def test_parse_args_no_file(monkeypatch: MonkeyPatch) -> None:
     args = parse_args()
     assert args.xml_file is None
     assert args.no_color is False
+    assert args.format == "human"
 
 
 def test_parse_args_with_file(monkeypatch: MonkeyPatch) -> None:
@@ -105,6 +106,7 @@ def test_parse_args_with_file(monkeypatch: MonkeyPatch) -> None:
     args = parse_args()
     assert args.xml_file == "coverage.xml"
     assert args.no_color is False
+    assert args.format == "human"
 
 
 def test_parse_args_no_color_flag(monkeypatch: MonkeyPatch) -> None:
@@ -112,6 +114,14 @@ def test_parse_args_no_color_flag(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", test_args)
     args = parse_args()
     assert args.no_color is True
+    assert args.format == "human"
+
+
+def test_parse_args_format_json(monkeypatch: MonkeyPatch) -> None:
+    test_args = ["prog", "--format", "json"]
+    monkeypatch.setattr(sys, "argv", test_args)
+    args = parse_args()
+    assert args.format == "json"
 
 
 # --- Tests for `print_uncovered_sections` ---


### PR DESCRIPTION
## Summary
- add `--format` flag with JSON output support
- normalize input paths and remove ANSI color from JSON mode
- test JSON output and CLI argument parsing

## Testing
- `ruff check src/ tests/`
- `ty check src/ tests/`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e352d519c83279ea2a5e34c1ce567