### PR TITLE
feat: decouple output formatting and add environment metadata

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,13 +20,13 @@
 
 ### Phase 2: Decouple formatting/output from Logic
 
-* [ ] Add an item to the JSON output (and update the schema) to indicate the "environment" like what coverage file was run, and other important details.
-* [ ] Make the behavior with respect to different command line flags consistent across output formats.
-* [ ] Move all printing/formatting into dedicated module: `showcov/output.py`.
-* [ ] Introduce output selection via a registry or strategy pattern so `--format` selects formatter.
-* [ ] Update `main()` to call into the new output layer via a clean API, passing model instances.
-* [ ] Ensure the human formatter still honors `--no-color` and that JSON formatter remains colorless.
-* [ ] Add tests for the new output module (unit tests invoking formatters with deterministic input).
+* [x] Add an item to the JSON output (and update the schema) to indicate the "environment" like what coverage file was run, and other important details.
+* [x] Make the behavior with respect to different command line flags consistent across output formats.
+* [x] Move all printing/formatting into dedicated module: `showcov/output.py`.
+* [x] Introduce output selection via a registry or strategy pattern so `--format` selects formatter.
+* [x] Update `main()` to call into the new output layer via a clean API, passing model instances.
+* [x] Ensure the human formatter still honors `--no-color` and that JSON formatter remains colorless.
+* [x] Add tests for the new output module (unit tests invoking formatters with deterministic input).
 
 ### Phase 3: Feature Completion and Determinism Guarantees (LLM Usability focus)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "showcov"
-  version = "0.0.3"
+  version = "0.0.4"
   description = "Print out uncovered code."
   readme = "README.md"
   authors = [

--- a/src/showcov/cli.py
+++ b/src/showcov/cli.py
@@ -1,53 +1,26 @@
 import argparse
-import json
 import logging
 import sys
-from importlib import resources
-from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from colorama import Fore, Style
-from colorama import init as colorama_init
 from defusedxml import ElementTree
-from jsonschema import validate
 
-from . import __version__
 from .core import (
     CoverageXMLNotFoundError,
-    UncoveredSection,
     build_sections,
     determine_xml_file,
     gather_uncovered_lines,
     parse_large_xml,
 )
-
-# Load JSON schema once
-SCHEMA = json.loads(resources.files("showcov.data").joinpath("schema.json").read_text(encoding="utf-8"))
-
-# Initialize colorama
-colorama_init(autoreset=True)
+from .output import FORMATTERS
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from xml.etree.ElementTree import Element  # noqa: S405
-
-# ANSI color codes (cross-platform)
-RESET = Style.RESET_ALL
-BOLD = Style.BRIGHT
-YELLOW = Fore.YELLOW
-CYAN = Fore.CYAN
-MAGENTA = Fore.MAGENTA
-GREEN = Fore.GREEN
-RED = Fore.RED
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
-
-
-def disable_colors() -> None:
-    """Disable ANSI color codes."""
-    global RESET, BOLD, YELLOW, CYAN, MAGENTA, GREEN, RED  # noqa: PLW0603
-    RESET = BOLD = YELLOW = CYAN = MAGENTA = GREEN = RED = ""
 
 
 def parse_args() -> argparse.Namespace:
@@ -79,62 +52,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def print_uncovered_sections(sections: list[UncoveredSection], *, context_lines: int) -> None:
-    """Print uncovered sections from files."""
-    root = Path.cwd().resolve()
-    for section in sections:
-        try:
-            rel = section.file.resolve().relative_to(root)
-        except ValueError:
-            rel = section.file.resolve()
-        print(f"\n{BOLD}{YELLOW}Uncovered sections in {rel.as_posix()}:{RESET}")
-
-        try:
-            with section.file.open(encoding="utf-8") as f:
-                file_lines = [ln.rstrip("\n") for ln in f.readlines()]
-        except OSError:
-            logger.exception("Could not open %s", section.file)
-            for start, end in section.ranges:
-                text = (
-                    f"  {CYAN}Lines {start}-{end}{RESET}" if start != end else f"  {CYAN}Line {start}{RESET}"
-                )
-                print(text)
-            continue
-
-        for start, end in section.ranges:
-            header = (
-                f"  {BOLD}{CYAN}Lines {start}-{end}:{RESET}"
-                if start != end
-                else f"  {BOLD}{CYAN}Line {start}:{RESET}"
-            )
-            print(header)
-            start_idx = max(1, start - context_lines)
-            end_idx = min(len(file_lines), end + context_lines)
-            for ln in range(start_idx, end_idx + 1):
-                content = file_lines[ln - 1] if 1 <= ln <= len(file_lines) else "<line not found>"
-                if start <= ln <= end:
-                    print(f"    {MAGENTA}{ln:4d}{RESET}: {content}")
-                else:
-                    print(f"    {ln:4d}: {content}")
-            print()
-
-
-def print_json_output(sections: list[UncoveredSection], *, with_code: bool, context_lines: int) -> None:
-    """Print uncovered sections in JSON format."""
-    data: dict[str, object] = {
-        "version": __version__,
-        "files": [sec.to_dict(with_code=with_code, context_lines=context_lines) for sec in sections],
-    }
-
-    validate(data, SCHEMA)
-    print(json.dumps(data, indent=2, sort_keys=True))
-
-
 def main() -> None:
     """Entry point for the script."""
     args = parse_args()
-    if args.no_color or args.format == "json":
-        disable_colors()
     try:
         xml_file: Path = determine_xml_file(args.xml_file)
     except CoverageXMLNotFoundError:
@@ -155,17 +75,15 @@ def main() -> None:
     uncovered = gather_uncovered_lines(cast("Element", root))
     sections = build_sections(uncovered)
 
-    if not sections:
-        if args.format == "json":
-            print_json_output([], with_code=args.with_code, context_lines=args.context_lines)
-        else:
-            print(f"{GREEN}{BOLD}No uncovered lines found!{RESET}")
-        return
-
-    if args.format == "json":
-        print_json_output(sections, with_code=args.with_code, context_lines=args.context_lines)
-    else:
-        print_uncovered_sections(sections, context_lines=args.context_lines)
+    formatter = FORMATTERS[args.format]
+    output = formatter(
+        sections,
+        context_lines=args.context_lines,
+        with_code=args.with_code,
+        coverage_xml=xml_file,
+        color=not args.no_color,
+    )
+    print(output)
 
 
 if __name__ == "__main__":

--- a/src/showcov/data/schema.json
+++ b/src/showcov/data/schema.json
@@ -9,6 +9,17 @@
       "type": "string",
       "pattern": "^\\d+\\.\\d+\\.\\d+$"
     },
+    "environment": {
+      "description": "Execution environment details.",
+      "type": "object",
+      "properties": {
+        "coverage_xml": {"type": "string"},
+        "context_lines": {"type": "integer", "minimum": 0},
+        "with_code": {"type": "boolean"}
+      },
+      "required": ["coverage_xml", "context_lines", "with_code"],
+      "additionalProperties": false
+    },
     "files": {
       "description": "List of source files with uncovered code sections.",
       "type": "array",
@@ -60,6 +71,7 @@
   },
   "required": [
     "version",
+    "environment",
     "files"
   ],
   "additionalProperties": false

--- a/src/showcov/output.py
+++ b/src/showcov/output.py
@@ -1,0 +1,133 @@
+"""Output formatting utilities for showcov."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+from colorama import Fore, Style
+from colorama import init as colorama_init
+from jsonschema import validate
+
+from . import __version__
+
+if TYPE_CHECKING:
+    from .core import UncoveredSection
+
+colorama_init(autoreset=True)
+
+# Load JSON schema once
+SCHEMA = json.loads(resources.files("showcov.data").joinpath("schema.json").read_text(encoding="utf-8"))
+
+
+class Formatter(Protocol):
+    def __call__(
+        self,
+        sections: list[UncoveredSection],
+        *,
+        context_lines: int,
+        with_code: bool,
+        coverage_xml: Path,
+        color: bool,
+    ) -> str: ...
+
+
+def _colors(*, enabled: bool) -> dict[str, str]:
+    if not enabled:
+        return {"RESET": "", "BOLD": "", "YELLOW": "", "CYAN": "", "MAGENTA": "", "GREEN": "", "RED": ""}
+    return {
+        "RESET": Style.RESET_ALL,
+        "BOLD": Style.BRIGHT,
+        "YELLOW": Fore.YELLOW,
+        "CYAN": Fore.CYAN,
+        "MAGENTA": Fore.MAGENTA,
+        "GREEN": Fore.GREEN,
+        "RED": Fore.RED,
+    }
+
+
+def format_human(
+    sections: list[UncoveredSection],
+    *,
+    context_lines: int,
+    with_code: bool,  # noqa: ARG001 - kept for consistent signature
+    coverage_xml: Path,  # noqa: ARG001
+    color: bool,
+) -> str:
+    colors = _colors(enabled=color)
+    if not sections:
+        return f"{colors['GREEN']}{colors['BOLD']}No uncovered lines found!{colors['RESET']}"
+
+    root = Path.cwd().resolve()
+    parts: list[str] = []
+    for section in sections:
+        try:
+            rel = section.file.resolve().relative_to(root)
+        except ValueError:
+            rel = section.file.resolve()
+        parts.append(
+            f"\n{colors['BOLD']}{colors['YELLOW']}Uncovered sections in {rel.as_posix()}:{colors['RESET']}"
+        )
+        try:
+            with section.file.open(encoding="utf-8") as f:
+                file_lines = [ln.rstrip("\n") for ln in f.readlines()]
+        except OSError:
+            for start, end in section.ranges:
+                text = (
+                    f"  {colors['CYAN']}Lines {start}-{end}{colors['RESET']}"
+                    if start != end
+                    else f"  {colors['CYAN']}Line {start}{colors['RESET']}"
+                )
+                parts.append(text)
+            continue
+        for start, end in section.ranges:
+            header = (
+                f"  {colors['BOLD']}{colors['CYAN']}Lines {start}-{end}:{colors['RESET']}"
+                if start != end
+                else f"  {colors['BOLD']}{colors['CYAN']}Line {start}:{colors['RESET']}"
+            )
+            parts.append(header)
+            start_idx = max(1, start - context_lines)
+            end_idx = min(len(file_lines), end + context_lines)
+            for ln in range(start_idx, end_idx + 1):
+                content = file_lines[ln - 1] if 1 <= ln <= len(file_lines) else "<line not found>"
+                if start <= ln <= end:
+                    parts.append(f"    {colors['MAGENTA']}{ln:4d}{colors['RESET']}: {content}")
+                else:
+                    parts.append(f"    {ln:4d}: {content}")
+            parts.append("")
+    return "\n".join(parts).lstrip("\n")
+
+
+def format_json(
+    sections: list[UncoveredSection],
+    *,
+    context_lines: int,
+    with_code: bool,
+    coverage_xml: Path,
+    color: bool,  # noqa: ARG001
+) -> str:
+    root = Path.cwd().resolve()
+    try:
+        xml_path = coverage_xml.resolve().relative_to(root)
+    except ValueError:
+        xml_path = coverage_xml.resolve()
+    data: dict[str, object] = {
+        "version": __version__,
+        "environment": {
+            "coverage_xml": xml_path.as_posix(),
+            "context_lines": context_lines,
+            "with_code": with_code,
+        },
+        "files": [sec.to_dict(with_code=with_code, context_lines=context_lines) for sec in sections],
+    }
+    validate(data, SCHEMA)
+    return json.dumps(data, indent=2, sort_keys=True)
+
+
+FORMATTERS: dict[str, Formatter] = {
+    "human": format_human,
+    "json": format_json,
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,18 +9,25 @@ from _pytest.monkeypatch import MonkeyPatch
 from jsonschema import ValidationError, validate
 
 from showcov import __version__
-from showcov.cli import main, print_json_output
+from showcov.cli import main
 from showcov.core import build_sections
+from showcov.output import format_json
 
 
-def test_print_json_output(tmp_path: Path, capsys: CaptureFixture) -> None:
+def test_format_json_output(tmp_path: Path) -> None:
     source_file = tmp_path / "dummy.py"
     source_file.write_text("print('hi')\n")
     sections = build_sections({source_file: [1, 2, 4]})
-    print_json_output(sections, with_code=False, context_lines=0)
-    captured = capsys.readouterr().out
-    assert "\x1b" not in captured
-    data = json.loads(captured)
+    out = format_json(
+        sections,
+        with_code=False,
+        context_lines=0,
+        coverage_xml=tmp_path / "cov.xml",
+        color=True,
+    )
+    assert "\x1b" not in out
+    data = json.loads(out)
+    assert data["environment"]["coverage_xml"] == (tmp_path / "cov.xml").resolve().as_posix()
     assert data["files"][0]["file"] == source_file.resolve().as_posix()
     assert data["files"][0]["uncovered"] == [
         {"start": 1, "end": 2},
@@ -53,6 +60,7 @@ def test_main_json_output(tmp_path: Path, monkeypatch: MonkeyPatch, capsys: Capt
     captured = capsys.readouterr().out
     assert "\x1b" not in captured
     data = json.loads(captured)
+    assert data["environment"]["coverage_xml"] == xml_file.resolve().as_posix()
     assert data["files"][0]["file"] == source_file.resolve().as_posix()
     assert data["files"][0]["uncovered"] == [{"start": 1, "end": 1}]
 
@@ -81,15 +89,22 @@ def test_main_json_output_no_uncovered(
     main()
     captured = capsys.readouterr().out
     data = json.loads(captured)
+    assert data["environment"]["coverage_xml"] == xml_file.resolve().as_posix()
     assert data["files"] == []
 
 
-def test_print_json_output_with_code_and_context(tmp_path: Path, capsys: CaptureFixture) -> None:
+def test_format_json_output_with_code_and_context(tmp_path: Path) -> None:
     source_file = tmp_path / "dummy.py"
     source_file.write_text("a\nb\nc\n")
     sections = build_sections({source_file: [2]})
-    print_json_output(sections, with_code=True, context_lines=1)
-    data = json.loads(capsys.readouterr().out)
+    out = format_json(
+        sections,
+        with_code=True,
+        context_lines=1,
+        coverage_xml=tmp_path / "cov.xml",
+        color=True,
+    )
+    data = json.loads(out)
     assert data["files"][0]["uncovered"][0]["lines"] == ["a", "b", "c"]
 
 
@@ -97,8 +112,14 @@ def test_json_schema_validation(tmp_path: Path, capsys: CaptureFixture) -> None:
     source_file = tmp_path / "dummy.py"
     source_file.write_text("print('hi')\n")
     sections = build_sections({source_file: [1]})
-    print_json_output(sections, with_code=True, context_lines=0)
-    data = json.loads(capsys.readouterr().out)
+    out = format_json(
+        sections,
+        with_code=True,
+        context_lines=0,
+        coverage_xml=tmp_path / "cov.xml",
+        color=True,
+    )
+    data = json.loads(out)
     schema = json.loads(resources.files("showcov.data").joinpath("schema.json").read_text(encoding="utf-8"))
     validate(data, schema)
     bad = {"version": __version__, "files": [{"file": "x", "uncovered": [{"start": "a", "end": 2}]}]}
@@ -106,13 +127,17 @@ def test_json_schema_validation(tmp_path: Path, capsys: CaptureFixture) -> None:
         validate(bad, schema)
 
 
-def test_print_json_output_relative_path(
-    tmp_path: Path, capsys: CaptureFixture, monkeypatch: MonkeyPatch
-) -> None:
+def test_format_json_output_relative_path(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     source_file = Path("dummy.py")
     source_file.write_text("print('hi')\n", encoding="utf-8")
     sections = build_sections({source_file: [1]})
-    print_json_output(sections, with_code=False, context_lines=0)
-    data = json.loads(capsys.readouterr().out)
+    out = format_json(
+        sections,
+        with_code=False,
+        context_lines=0,
+        coverage_xml=Path("cov.xml"),
+        color=True,
+    )
+    data = json.loads(out)
     assert data["files"][0]["file"] == "dummy.py"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from showcov.core import build_sections
+from showcov.output import FORMATTERS, format_human
+
+
+def test_format_human_respects_color(tmp_path: Path) -> None:
+    src = tmp_path / "x.py"
+    src.write_text("a\n")
+    sections = build_sections({src: [1]})
+    colored = format_human(
+        sections,
+        context_lines=0,
+        with_code=False,
+        coverage_xml=tmp_path / "cov.xml",
+        color=True,
+    )
+    plain = format_human(
+        sections,
+        context_lines=0,
+        with_code=False,
+        coverage_xml=tmp_path / "cov.xml",
+        color=False,
+    )
+    assert "\x1b" in colored
+    assert "\x1b" not in plain
+
+
+def test_format_registry() -> None:
+    assert set(FORMATTERS) == {"human", "json"}


### PR DESCRIPTION
## Summary
- add output module with strategy-based registry for human and JSON formatters
- include environment details like coverage file, context lines, and with-code in JSON output
- refactor CLI to use the output layer and honor no-color consistently

## Testing
- `ruff check src/ tests/`
- `uv run ty check src/ tests/`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e44070ae4832792ba9f7ab82bd448