### PR TITLE
feat: add round-trip and snapshot tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [0.0.6] - 2025-08-02
+
+### Added
+- add JSON round-trip parsing via `parse_json_output` and `UncoveredSection.from_dict`
+- add snapshot tests for JSON output and LLM prompts
+- add edge-case tests for missing source files and context line handling
+
+### Fixed
+- handle negative context-line values without crashing
+
+---
+
 ## [0.0.4] - 2025-08-02
 
 ### Added

--- a/LIVELOG.md
+++ b/LIVELOG.md
@@ -5,3 +5,12 @@
 - ran `.venv/bin/ruff check src/ tests/`
 - ran `.venv/bin/ty check src/ tests/`
 - ran `.venv/bin/pytest`
+
+## 2025-08-02T21:37Z
+- start Phase 4 tasks: round-trip validation, snapshots, edge-case tests
+
+## 2025-08-02T21:41Z
+- ran `.venv/bin/ruff format src/ tests/`
+- ran `.venv/bin/ruff check src/ tests/`
+- ran `.venv/bin/ty check src/ tests/`
+- ran `.venv/bin/pytest`

--- a/TODO.md
+++ b/TODO.md
@@ -37,9 +37,9 @@
 
 ### Phase 4: Testing Enhancements beyond Basic Correctness
 
-* [ ] Add round-trip validation: uncovered → JSON → parsed → == original model instances.
-* [ ] Add snapshot tests of JSON output and sample prompts to LLMs for smoke-checking usability.
-* [ ] Expand coverage for edge/corner cases introduced by new features (missing source files when embedding, invalid context ranges, etc.).
+* [x] Add round-trip validation: uncovered → JSON → parsed → == original model instances.
+* [x] Add snapshot tests of JSON output and sample prompts to LLMs for smoke-checking usability.
+* [x] Expand coverage for edge/corner cases introduced by new features (missing source files when embedding, invalid context ranges, etc.).
 
 ### Phase 5: Protocol/tooling Integration Readiness
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "showcov"
-  version = "0.0.5"
+  version = "0.0.6"
   description = "Print out uncovered code."
   readme = "README.md"
   authors = [

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for test data

--- a/tests/data/sample.py
+++ b/tests/data/sample.py
@@ -1,0 +1,6 @@
+def foo() -> None:
+    pass
+
+
+def bar() -> int:
+    return 42

--- a/tests/snapshots/json_output.json
+++ b/tests/snapshots/json_output.json
@@ -1,0 +1,45 @@
+{
+  "environment": {
+    "context_lines": 1,
+    "coverage_xml": "coverage.xml",
+    "with_code": true
+  },
+  "files": [
+    {
+      "file": "tests/data/sample.py",
+      "uncovered": [
+        {
+          "end": 5,
+          "source": [
+            {
+              "code": "def foo() -> None:",
+              "line": 1
+            },
+            {
+              "code": "    pass",
+              "line": 2
+            },
+            {
+              "code": "",
+              "line": 3
+            },
+            {
+              "code": "",
+              "line": 4
+            },
+            {
+              "code": "def bar() -> int:",
+              "line": 5
+            },
+            {
+              "code": "    return 42",
+              "line": 6
+            }
+          ],
+          "start": 2
+        }
+      ]
+    }
+  ],
+  "version": "0.0.5"
+}

--- a/tests/snapshots/llm_prompt.txt
+++ b/tests/snapshots/llm_prompt.txt
@@ -1,0 +1,47 @@
+Please review the following coverage data and suggest tests:
+{
+  "environment": {
+    "context_lines": 1,
+    "coverage_xml": "coverage.xml",
+    "with_code": true
+  },
+  "files": [
+    {
+      "file": "tests/data/sample.py",
+      "uncovered": [
+        {
+          "end": 5,
+          "source": [
+            {
+              "code": "def foo() -> None:",
+              "line": 1
+            },
+            {
+              "code": "    pass",
+              "line": 2
+            },
+            {
+              "code": "",
+              "line": 3
+            },
+            {
+              "code": "",
+              "line": 4
+            },
+            {
+              "code": "def bar() -> int:",
+              "line": 5
+            },
+            {
+              "code": "    return 42",
+              "line": 6
+            }
+          ],
+          "start": 2
+        }
+      ]
+    }
+  ],
+  "version": "0.0.5"
+}
+

--- a/tests/test_round_trip.py
+++ b/tests/test_round_trip.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import cast
+
+from showcov.core import UncoveredSection, build_sections
+from showcov.output import FORMATTERS, parse_json_output
+
+
+def test_json_round_trip(tmp_path: Path) -> None:
+    src = tmp_path / "x.py"
+    src.write_text("a\nb\n")
+    sections = build_sections({src: [1, 2]})
+    json_out = FORMATTERS["json"](
+        sections,
+        context_lines=1,
+        with_code=True,
+        coverage_xml=tmp_path / "cov.xml",
+        color=False,
+    )
+    parsed = parse_json_output(json_out)
+    assert parsed == sections
+
+
+def test_to_dict_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.py"
+    section = UncoveredSection(missing, [(1, 1)])
+    out = section.to_dict(with_code=True, context_lines=1)
+    uncovered = cast("list[dict[str, object]]", out["uncovered"])
+    first: dict[str, object] = uncovered[0]
+    assert "source" not in first
+
+
+def test_negative_context_lines(tmp_path: Path) -> None:
+    src = tmp_path / "a.py"
+    src.write_text("a\nb\n")
+    section = UncoveredSection(src, [(1, 1)])
+    out = section.to_dict(with_code=True, context_lines=-5)
+    uncovered = cast("list[dict[str, object]]", out["uncovered"])
+    source = cast("list[dict[str, object]]", uncovered[0]["source"])
+    lines = [cast("int", s["line"]) for s in source]
+    assert lines == [1]
+
+
+def test_context_lines_exceed_file(tmp_path: Path) -> None:
+    src = tmp_path / "a.py"
+    src.write_text("a\nb\n")
+    section = UncoveredSection(src, [(2, 2)])
+    out = section.to_dict(with_code=True, context_lines=10)
+    uncovered = cast("list[dict[str, object]]", out["uncovered"])
+    source = cast("list[dict[str, object]]", uncovered[0]["source"])
+    lines = [cast("int", s["line"]) for s in source]
+    assert lines == [1, 2]

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from showcov.core import build_sections
+from showcov.output import FORMATTERS
+
+
+def _build_sections() -> list:
+    src = Path("tests/data/sample.py")
+    return build_sections({src: [2, 4, 5]})
+
+
+def test_json_output_snapshot() -> None:
+    sections = _build_sections()
+    json_out = FORMATTERS["json"](
+        sections,
+        context_lines=1,
+        with_code=True,
+        coverage_xml=Path("coverage.xml"),
+        color=False,
+    )
+    expected = Path("tests/snapshots/json_output.json").read_text(encoding="utf-8").rstrip("\n")
+    assert json_out == expected
+
+
+def test_llm_prompt_snapshot() -> None:
+    sections = _build_sections()
+    json_out = FORMATTERS["json"](
+        sections,
+        context_lines=1,
+        with_code=True,
+        coverage_xml=Path("coverage.xml"),
+        color=False,
+    )
+    prompt = f"Please review the following coverage data and suggest tests:\n{json_out}\n"
+    expected = Path("tests/snapshots/llm_prompt.txt").read_text(encoding="utf-8").rstrip("\n")
+    assert prompt.rstrip("\n") == expected


### PR DESCRIPTION
## Summary
- add JSON round-trip parsing utilities and clamp context lines
- snapshot JSON output and LLM prompts for deterministic validation
- expand tests for missing source files and extreme context ranges

## Testing
- `.venv/bin/ruff format src/ tests/`
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e83d5c2c483279542abbea62975c3