### PR TITLE
refactor: centralize config and embed schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.0.9] - 2025-08-02
+
+### Changed
+- centralize configuration constants in `config.py`
+- remove module-level side effects and load schema via package resources
+
+---
+
 ## [0.0.8] - 2025-08-02
 
 ### Added

--- a/LIVELOG.md
+++ b/LIVELOG.md
@@ -28,3 +28,10 @@
 - ran `.venv/bin/ruff check src/ tests/`
 - ran `.venv/bin/ty check src/ tests/`
 - ran `.venv/bin/pytest`
+## 2025-08-03T00:08Z
+- start implementing Group A tasks: schema packaging and config constants
+## 2025-08-03T00:10Z
+- ran `.venv/bin/ruff format src/ tests/`
+- ran `.venv/bin/ruff check src/ tests/`
+- ran `.venv/bin/ty check src/ tests/`
+- ran `.venv/bin/pytest`

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 ## Group A: schema packaging and config constants
 
-- [ ] Embed schema.json via importlib.resources.files("showcov.data") at build time and list it under [tool.uv_build].resources to avoid runtime FileNotFoundError when installed as a wheel.
-- [ ] Move `CONSECUTIVE_STEP` and other constants to `src/showcov/config.py`
-- [ ] enumerate and eliminate module-level side effects
+- [x] Embed schema.json via importlib.resources.files("showcov.data") at build time and list it under [tool.uv_build].resources to avoid runtime FileNotFoundError when installed as a wheel.
+- [x] Move `CONSECUTIVE_STEP` and other constants to `src/showcov/config.py`
+- [x] enumerate and eliminate module-level side effects
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "showcov"
-  version = "0.0.8"
+  version = "0.0.9"
   description = "Print out uncovered code."
   readme = "README.md"
   authors = [

--- a/src/showcov/__init__.py
+++ b/src/showcov/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
 
 try:
@@ -6,8 +7,15 @@ try:
 except PackageNotFoundError:  # pragma: no cover - fallback for src layout
     __version__ = "0.0.0"
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
+
+
+def __getattr__(name: str) -> object:
+    try:
+        return import_module(f"{__name__}.{name}")
+    except ModuleNotFoundError as e:  # pragma: no cover - defensive
+        msg = f"module {__name__!r} has no attribute {name!r}"
+        raise AttributeError(msg) from e
 
 
 __all__ = ["__version__", "logger"]

--- a/src/showcov/cli.py
+++ b/src/showcov/cli.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import logging
 import sys
 from fnmatch import fnmatch
 from pathlib import Path
 
 import click
+from colorama import init as colorama_init
 from defusedxml import ElementTree
 
 from showcov import logger
+from showcov.config import LOG_FORMAT
 from showcov.core import (
     CoverageXMLNotFoundError,
     UncoveredSection,
@@ -79,6 +82,8 @@ def main(
     output: Path | None = None,
 ) -> None:
     """Show uncovered lines from a coverage XML report."""
+    logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+    colorama_init(autoreset=True)
     try:
         resolved_xml = determine_xml_file(str(xml_file) if xml_file else None)
     except CoverageXMLNotFoundError:

--- a/src/showcov/config.py
+++ b/src/showcov/config.py
@@ -1,0 +1,22 @@
+"""Central configuration and constants for ``showcov``."""
+
+from __future__ import annotations
+
+import json
+from functools import cache
+from importlib import resources
+
+# Step size when grouping consecutive uncovered line numbers.
+CONSECUTIVE_STEP = 1
+
+# Default logging format used by the CLI entry point.
+LOG_FORMAT = "%(levelname)s: %(message)s"
+
+
+@cache
+def get_schema() -> dict[str, object]:
+    """Load and cache the JSON schema for structured output."""
+    return json.loads(resources.files("showcov.data").joinpath("schema.json").read_text(encoding="utf-8"))
+
+
+__all__ = ["CONSECUTIVE_STEP", "LOG_FORMAT", "get_schema"]

--- a/src/showcov/core.py
+++ b/src/showcov/core.py
@@ -18,13 +18,10 @@ from typing import TYPE_CHECKING, Optional, cast
 from defusedxml import ElementTree
 
 from showcov import logger
+from showcov.config import CONSECUTIVE_STEP
 
 if TYPE_CHECKING:
     from xml.etree.ElementTree import Element  # noqa: S405
-
-
-# Constants
-CONSECUTIVE_STEP = 1
 
 
 class CoverageXMLNotFoundError(Exception):

--- a/src/showcov/output.py
+++ b/src/showcov/output.py
@@ -3,21 +3,15 @@
 from __future__ import annotations
 
 import json
-from importlib import resources
 from pathlib import Path
 from typing import Protocol
 
 from colorama import Fore, Style
-from colorama import init as colorama_init
 from jsonschema import validate
 
 from showcov import __version__
+from showcov.config import get_schema
 from showcov.core import UncoveredSection
-
-colorama_init(autoreset=True)
-
-# Load JSON schema once
-SCHEMA = json.loads(resources.files("showcov.data").joinpath("schema.json").read_text(encoding="utf-8"))
 
 
 class Formatter(Protocol):
@@ -123,14 +117,14 @@ def format_json(
         },
         "files": [sec.to_dict(with_code=with_code, context_lines=context_lines) for sec in sections],
     }
-    validate(data, SCHEMA)
+    validate(data, get_schema())
     return json.dumps(data, indent=2, sort_keys=True)
 
 
 def parse_json_output(data: str) -> list[UncoveredSection]:
     """Parse JSON coverage data into :class:`UncoveredSection` instances."""
     obj = json.loads(data)
-    validate(obj, SCHEMA)
+    validate(obj, get_schema())
     files = obj.get("files", [])
     return [UncoveredSection.from_dict(f) for f in files]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,56 @@
+"""Tests for configuration helpers and module side-effect behavior."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+
+import colorama
+
+
+def test_get_schema_cached(monkeypatch):
+    """``get_schema`` should load the schema once and cache the result."""
+    from showcov import config
+
+    config.get_schema.cache_clear()
+    calls = 0
+    original = config.resources.files
+
+    def tracking_files(package: str):
+        nonlocal calls
+        calls += 1
+        return original(package)
+
+    monkeypatch.setattr(config.resources, "files", tracking_files)
+
+    schema1 = config.get_schema()
+    schema2 = config.get_schema()
+
+    assert schema1 == schema2
+    assert calls == 1
+
+
+def test_import_has_no_side_effects(monkeypatch):
+    """Importing the package should not configure logging or colorama."""
+    basic_called = False
+    init_called = False
+
+    def fake_basic(*args, **kwargs):
+        nonlocal basic_called
+        basic_called = True
+
+    def fake_init(*args, **kwargs):
+        nonlocal init_called
+        init_called = True
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basic)
+    monkeypatch.setattr(colorama, "init", fake_init)
+
+    sys.modules.pop("showcov", None)
+    sys.modules.pop("showcov.output", None)
+
+    importlib.import_module("showcov.output")
+
+    assert not basic_called
+    assert not init_called


### PR DESCRIPTION
## Summary
- centralize constants and logging format in a new `config` module
- load the JSON schema via `importlib.resources` and drop module-level side effects
- guard package imports with a lazy `__getattr__`

## Testing
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ea795c6f083278c7d7be2fd4f1392