### PR TITLE
test: refactor tests with shared fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.0.11] - 2025-08-03
+
+### Changed
+- refactor tests with shared fixtures and parameterization
+
+---
+
 ## [0.0.10] - 2025-08-03
 
 ### Changed

--- a/LIVELOG.md
+++ b/LIVELOG.md
@@ -42,3 +42,11 @@
 - ran `.venv/bin/ruff check src/ tests/`
 - ran `.venv/bin/ty check src/ tests/`
 - ran `.venv/bin/pytest`
+
+## 2025-08-03T00:29Z
+- start implementing Group C tasks: improved testing infrastructure
+## 2025-08-03T00:35Z
+- ran `.venv/bin/ruff format src/ tests/`
+- ran `.venv/bin/ruff check src/ tests/`
+- ran `.venv/bin/ty check src/ tests/`
+- ran `.venv/bin/pytest`

--- a/TODO.md
+++ b/TODO.md
@@ -15,11 +15,11 @@
 
 ## Group C: improved testing infrastructure
 
-- [ ] Replace inline XML strings in tests with reusable fixture factories
+- [x] Replace inline XML strings in tests with reusable fixture factories
   - Move to `conftest.py` or shared `test_utils.py`
-- [ ] Define a reusable test fixture for `CliRunner`
-- [ ] Parameterize tests with `pytest.mark.parametrize` where appropriate
-- [ ] Improve tests using parameterization, reusable mocks and fixtures, and make them more consistent with idiomatic pytest usage
+- [x] Define a reusable test fixture for `CliRunner`
+- [x] Parameterize tests with `pytest.mark.parametrize` where appropriate
+- [x] Improve tests using parameterization, reusable mocks and fixtures, and make them more consistent with idiomatic pytest usage
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "showcov"
-  version = "0.0.10"
+  version = "0.0.11"
   description = "Print out uncovered code."
   readme = "README.md"
   authors = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from typing import TYPE_CHECKING
+
+import pytest
+from click.testing import CliRunner
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+LinesSpec = Mapping[int, str | int] | Iterable[int]
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    """Return a Click CLI runner for invoking the command-line interface."""
+    return CliRunner()
+
+
+@pytest.fixture
+def coverage_xml_content() -> Callable[..., str]:
+    def build(mapping: Mapping[Path | str, LinesSpec], *, sources: Path | None = None) -> str:
+        classes: list[str] = []
+        for file, lines in mapping.items():
+            items = lines.items() if isinstance(lines, Mapping) else ((ln, 0) for ln in lines)
+            lines_xml = "".join(f'<line number="{ln}" hits="{hits}"/>' for ln, hits in items)
+            classes.append(f'<class filename="{file}"><lines>{lines_xml}</lines></class>')
+        classes_xml = "".join(classes)
+        sources_xml = f"<sources><source>{sources}</source></sources>" if sources else ""
+        return (
+            "<coverage>"
+            f"{sources_xml}"
+            f"<packages><package><classes>{classes_xml}</classes></package></packages>"
+            "</coverage>"
+        )
+
+    return build
+
+
+@pytest.fixture
+def coverage_xml_file(
+    tmp_path: Path,
+    coverage_xml_content: Callable[..., str],
+) -> Callable[..., Path]:
+    def write(
+        mapping: Mapping[Path | str, LinesSpec],
+        *,
+        sources: Path | None = None,
+        filename: str = "coverage.xml",
+    ) -> Path:
+        xml_content = coverage_xml_content(mapping, sources=sources)
+        xml_file = tmp_path / filename
+        xml_file.write_text(xml_content)
+        return xml_file
+
+    return write

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -5,33 +6,23 @@ from click.testing import CliRunner
 from showcov.cli import main
 
 
-def _build_xml(mapping: dict[Path, list[int]]) -> str:
-    classes = []
-    for file, lines in mapping.items():
-        lines_xml = "".join(f'<line number="{ln}" hits="0"/>' for ln in lines)
-        classes.append(f'<class filename="{file}"><lines>{lines_xml}</lines></class>')
-    inner = "".join(classes)
-    return f"<coverage><packages><package><classes>{inner}</classes></package></packages></coverage>"
-
-
-def test_cli_filters_and_output(tmp_path: Path) -> None:
+def test_cli_filters_and_output(
+    tmp_path: Path, cli_runner: CliRunner, coverage_xml_file: Callable[..., Path]
+) -> None:
     file_a = tmp_path / "a.py"
     file_a.write_text("a\n")
     file_b = tmp_path / "b.py"
     file_b.write_text("b\n")
-    xml_content = _build_xml({file_a: [1], file_b: [1]})
-    xml_file = tmp_path / "cov.xml"
-    xml_file.write_text(xml_content)
+    xml_file = coverage_xml_file({file_a: [1], file_b: [1]})
 
-    runner = CliRunner()
     # include only file_a
-    result = runner.invoke(main, ["--xml-file", str(xml_file), str(file_a)])
+    result = cli_runner.invoke(main, ["--xml-file", str(xml_file), str(file_a)])
     assert result.exit_code == 0
     assert str(file_a) in result.output
     assert str(file_b) not in result.output
 
     # include directory but exclude file_b
-    result = runner.invoke(
+    result = cli_runner.invoke(
         main,
         ["--xml-file", str(xml_file), str(tmp_path), "--exclude", "*b.py"],
     )
@@ -41,7 +32,7 @@ def test_cli_filters_and_output(tmp_path: Path) -> None:
 
     # write json output to file
     out_file = tmp_path / "out.json"
-    result = runner.invoke(
+    result = cli_runner.invoke(
         main,
         [
             "--xml-file",


### PR DESCRIPTION
## Summary
- add shared `cli_runner` and coverage XML fixtures
- refactor tests to use fixtures and pytest parameterization
- bump version to 0.0.11 and update changelog

## Testing
- `.venv/bin/ruff format src/ tests/`
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eabc4735c8327b8aec87192da38a3