### PR TITLE
feat: add path filter and validate CLI inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.0.12] - 2025-08-03
+
+### Added
+- add `PathFilter` utility for reusable path include/exclude logic
+
+### Changed
+- validate CLI input types with strict path and range checks
+- consolidate CLI error handling for coverage XML failures
+
+### Fixed
+- raise `ValueError` for negative `context_lines` inputs
+
+---
+
 ## [0.0.11] - 2025-08-03
 
 ### Changed

--- a/LIVELOG.md
+++ b/LIVELOG.md
@@ -50,3 +50,9 @@
 - ran `.venv/bin/ruff check src/ tests/`
 - ran `.venv/bin/ty check src/ tests/`
 - ran `.venv/bin/pytest`
+## 2025-08-03T00:44Z
+- start implementing Group E tasks: CLI and path filtering improvements
+- ran `.venv/bin/ruff format src/ tests/`
+- ran `.venv/bin/ruff check src/ tests/`
+- ran `.venv/bin/ty check src/ tests/`
+- ran `.venv/bin/pytest`

--- a/TODO.md
+++ b/TODO.md
@@ -31,11 +31,11 @@
 
 ## Group E: CLI and path-filtering improvements
 
-- [ ] Create a `PathFilter` utility class for include/exclude logic
+- [x] Create a `PathFilter` utility class for include/exclude logic
   - Encapsulate `_expand_paths()` and `_filter_sections()` into a reusable and testable component
-- [ ] Consolidate CLI error handling for `CoverageXMLNotFoundError`, `ElementTree.ParseError`, and `OSError`
-- [ ] Validate CLI input types with Click `Path(..., exists=True)` and `IntRange(min=0)`
-- [ ] Fail early on negative `context_lines` in non-CLI contexts
+- [x] Consolidate CLI error handling for `CoverageXMLNotFoundError`, `ElementTree.ParseError`, and `OSError`
+- [x] Validate CLI input types with Click `Path(..., exists=True)` and `IntRange(min=0)`
+- [x] Fail early on negative `context_lines` in non-CLI contexts
   - Raise `ValueError` in `UncoveredSection.to_dict()` if violated
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "showcov"
-  version = "0.0.11"
+  version = "0.0.12"
   description = "Print out uncovered code."
   readme = "README.md"
   authors = [

--- a/src/showcov/cli.py
+++ b/src/showcov/cli.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import sys
-from fnmatch import fnmatch
 from pathlib import Path
 
 import click
@@ -13,49 +12,17 @@ from showcov import logger
 from showcov.config import LOG_FORMAT
 from showcov.core import (
     CoverageXMLNotFoundError,
-    UncoveredSection,
     build_sections,
     determine_xml_file,
     gather_uncovered_lines_from_xml,
 )
 from showcov.output import get_formatter
-
-
-def _expand_paths(patterns: tuple[str, ...]) -> list[Path]:
-    """Expand files, directories, and globs into concrete paths."""
-    expanded: set[Path] = set()
-    for pat in patterns:
-        try:
-            matches = list(Path().glob(pat))
-        except NotImplementedError:
-            matches = []
-        if matches:
-            expanded.update(p.resolve() for p in matches)
-        else:
-            expanded.add(Path(pat).resolve())
-    return sorted(expanded)
-
-
-def _filter_sections(
-    sections: list[UncoveredSection],
-    includes: tuple[str, ...],
-    excludes: tuple[str, ...],
-) -> list[UncoveredSection]:
-    include_paths = _expand_paths(includes) if includes else []
-    if include_paths:
-        sections = [
-            sec
-            for sec in sections
-            if any(sec.file == p or (p.is_dir() and sec.file.is_relative_to(p)) for p in include_paths)
-        ]
-    if excludes:
-        sections = [sec for sec in sections if not any(fnmatch(sec.file.as_posix(), pat) for pat in excludes)]
-    return sections
+from showcov.path_filter import PathFilter
 
 
 @click.command()
-@click.argument("paths", nargs=-1, type=str)
-@click.option("--xml-file", type=click.Path(path_type=Path), help="Path to coverage XML file")
+@click.argument("paths", nargs=-1, type=click.Path(path_type=Path, exists=True))
+@click.option("--xml-file", type=click.Path(path_type=Path, exists=True), help="Path to coverage XML file")
 @click.option("--no-color", is_flag=True, help="Disable ANSI color codes in output")
 @click.option("--with-code", is_flag=True, help="Embed raw source lines for uncovered ranges in JSON output")
 @click.option(
@@ -71,7 +38,7 @@ def _filter_sections(
 @click.option("--exclude", multiple=True, help="Glob pattern to exclude from output")
 @click.option("--output", type=click.Path(path_type=Path), help="Write output to FILE instead of stdout")
 def main(
-    paths: tuple[str, ...],
+    paths: tuple[Path, ...],
     xml_file: Path | None,
     *,
     no_color: bool = False,
@@ -86,20 +53,14 @@ def main(
     colorama_init(autoreset=True)
     try:
         resolved_xml = determine_xml_file(str(xml_file) if xml_file else None)
-    except CoverageXMLNotFoundError:
-        sys.exit(1)
-
-    try:
         uncovered = gather_uncovered_lines_from_xml(resolved_xml)
-    except ElementTree.ParseError:
-        logger.exception("Error parsing XML file %s", resolved_xml)
-        sys.exit(1)
-    except OSError:
-        logger.exception("Error opening XML file %s", resolved_xml)
+    except (CoverageXMLNotFoundError, ElementTree.ParseError, OSError):
+        logger.exception("failed to read coverage XML")
         sys.exit(1)
 
     sections = build_sections(uncovered)
-    sections = _filter_sections(sections, paths, exclude)
+    path_filter = PathFilter(paths, exclude)
+    sections = path_filter.filter(sections)
     formatter = get_formatter(format_)
     output_text = formatter(
         sections,

--- a/src/showcov/core.py
+++ b/src/showcov/core.py
@@ -70,7 +70,9 @@ class UncoveredSection:
             Number of context lines to include before and after each uncovered
             range when ``with_code`` is ``True``.
         """
-        context_lines = max(0, context_lines)
+        if context_lines < 0:
+            msg = "context_lines must be non-negative"
+            raise ValueError(msg)
 
         root = Path.cwd().resolve()
         try:

--- a/src/showcov/path_filter.py
+++ b/src/showcov/path_filter.py
@@ -1,0 +1,45 @@
+"""Utilities for filtering :class:`UncoveredSection` objects by path."""
+
+from collections.abc import Iterable, Sequence
+from fnmatch import fnmatch
+from pathlib import Path
+
+from .core import UncoveredSection
+
+
+class PathFilter:
+    """Filter uncovered sections using include and exclude rules."""
+
+    def __init__(self, includes: Sequence[str | Path] = (), excludes: Sequence[str] = ()) -> None:
+        self._include_paths = self._expand_paths(includes) if includes else []
+        self._excludes = tuple(excludes)
+
+    @staticmethod
+    def _expand_paths(patterns: Sequence[str | Path]) -> list[Path]:
+        """Expand files, directories, and globs into concrete paths."""
+        expanded: set[Path] = set()
+        for pat in patterns:
+            pat_str = str(pat)
+            try:
+                matches = list(Path().glob(pat_str))
+            except NotImplementedError:
+                matches = []
+            if matches:
+                expanded.update(p.resolve() for p in matches)
+            else:
+                expanded.add(Path(pat).resolve())
+        return sorted(expanded)
+
+    def _match_includes(self, path: Path) -> bool:
+        if not self._include_paths:
+            return True
+        return any(path == p or (p.is_dir() and path.is_relative_to(p)) for p in self._include_paths)
+
+    def _match_excludes(self, path: Path) -> bool:
+        return any(fnmatch(path.as_posix(), pat) for pat in self._excludes)
+
+    def filter(self, sections: Iterable[UncoveredSection]) -> list[UncoveredSection]:
+        """Return sections that satisfy include/exclude rules."""
+        return [
+            sec for sec in sections if self._match_includes(sec.file) and not self._match_excludes(sec.file)
+        ]

--- a/tests/test_path_filter.py
+++ b/tests/test_path_filter.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from showcov.core import UncoveredSection
+from showcov.path_filter import PathFilter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_path_filter_include_exclude(tmp_path: Path) -> None:
+    file_a = tmp_path / "a.py"
+    file_a.write_text("a\n")
+    file_b = tmp_path / "b.py"
+    file_b.write_text("b\n")
+    sections = [
+        UncoveredSection(file_a, [(1, 1)]),
+        UncoveredSection(file_b, [(1, 1)]),
+    ]
+
+    pf = PathFilter([file_a], [])
+    out = pf.filter(sections)
+    assert [s.file for s in out] == [file_a]
+
+    pf = PathFilter([tmp_path], ["*b.py"])
+    out = pf.filter(sections)
+    assert [s.file for s in out] == [file_a]

--- a/tests/test_round_trip.py
+++ b/tests/test_round_trip.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import cast
 
+import pytest
+
 from showcov.core import UncoveredSection, build_sections
 from showcov.output import FORMATTERS, parse_json_output
 
@@ -33,11 +35,8 @@ def test_negative_context_lines(tmp_path: Path) -> None:
     src = tmp_path / "a.py"
     src.write_text("a\nb\n")
     section = UncoveredSection(src, [(1, 1)])
-    out = section.to_dict(with_code=True, context_lines=-5)
-    uncovered = cast("list[dict[str, object]]", out["uncovered"])
-    source = cast("list[dict[str, object]]", uncovered[0]["source"])
-    lines = [cast("int", s["line"]) for s in source]
-    assert lines == [1]
+    with pytest.raises(ValueError, match="context_lines must be non-negative"):
+        section.to_dict(with_code=True, context_lines=-5)
 
 
 def test_context_lines_exceed_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `PathFilter` utility to handle include/exclude patterns
- consolidate CLI error handling and validate path and range inputs
- raise `ValueError` for negative context lines and add dedicated tests

## Testing
- `.venv/bin/ruff format src/ tests/`
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eafb3a14083278e96f6addb2caef7