### PR TITLE
refactor: introduce Format enum and OutputMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.0.13] - 2025-08-03
+
+### Changed
+- replace string-based formatter flags with `Format` enum and `OutputMeta` dataclass
+
+---
+
 ## [0.0.12] - 2025-08-03
 
 ### Added

--- a/LIVELOG.md
+++ b/LIVELOG.md
@@ -56,3 +56,10 @@
 - ran `.venv/bin/ruff check src/ tests/`
 - ran `.venv/bin/ty check src/ tests/`
 - ran `.venv/bin/pytest`
+
+## 2025-08-03T01:21Z
+- start implementing Group F tasks: formatter API refactor and Enum cleanup
+- ran `.venv/bin/ruff format src/ tests/`
+- ran `.venv/bin/ruff check src/ tests/`
+- ran `.venv/bin/ty check src/ tests/`
+- ran `.venv/bin/pytest`

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ sections = build_sections(uncovered)
 This returns a list of `UncoveredSection` instances, which can be serialized to JSON using:
 
 ```python
-from showcov.output import format_json
+from showcov.output import OutputMeta, format_json
 
-output = format_json(sections, context_lines=1, with_code=True, coverage_xml=xml_path, color=False)
+meta = OutputMeta(context_lines=1, with_code=True, coverage_xml=xml_path, color=False)
+output = format_json(sections, meta)
 print(output)
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -42,10 +42,10 @@
 
 ## Group F: formatter API refactor and Enum cleanup
 
-- [ ] Replace `--format` string flags with a `Format` Enum
+- [x] Replace `--format` string flags with a `Format` Enum
   - Define `Format(str, Enum)` in `output.py`
   - Use Enum in `get_formatter()` and `click.Choice`
-- [ ] Introduce `OutputMeta` dataclass to consolidate formatter options
+- [x] Introduce `OutputMeta` dataclass to consolidate formatter options
   - Replace `context_lines`, `with_code`, `coverage_xml`, and `color` params with a single object
-- [ ] Replace format string literals in `FORMATTERS` with an Enum-based registry
+- [x] Replace format string literals in `FORMATTERS` with an Enum-based registry
   - Add `.from_str()` helper if needed for CLI compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "showcov"
-  version = "0.0.12"
+  version = "0.0.13"
   description = "Print out uncovered code."
   readme = "README.md"
   authors = [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,7 +26,7 @@ from showcov.core import (
     merge_blank_gap_groups,
     parse_large_xml,
 )
-from showcov.output import format_human
+from showcov.output import OutputMeta, format_human
 
 # Set logging level to capture output for tests
 logging.basicConfig(level=logging.INFO)
@@ -99,13 +99,13 @@ def test_format_human(tmp_path: Path, *, color: bool) -> None:
     source_file = tmp_path / "dummy.py"
     source_file.write_text("def foo():\n    pass\n\ndef bar():\n    return 42")
     sections = build_sections({source_file: [2, 4, 5]})
-    out = format_human(
-        sections,
+    meta = OutputMeta(
         context_lines=0,
         with_code=False,
         coverage_xml=tmp_path / "cov.xml",
         color=color,
     )
+    out = format_human(sections, meta)
     assert "Uncovered sections in" in out
     assert "Line" in out
     assert "2" in out
@@ -120,13 +120,13 @@ def test_format_human_sorted_files(tmp_path: Path) -> None:
     file_a.write_text("a=1\n")
     file_b.write_text("b=1\n")
     sections = build_sections({file_b: [1], file_a: [1]})
-    out = format_human(
-        sections,
+    meta = OutputMeta(
         context_lines=0,
         with_code=False,
         coverage_xml=tmp_path / "cov.xml",
         color=True,
     )
+    out = format_human(sections, meta)
     first = out.find(file_a.as_posix())
     second = out.find(file_b.as_posix())
     assert first < second
@@ -314,13 +314,13 @@ def test_merge_blank_gap_groups_no_merge():
 def test_format_human_file_open_error(tmp_path: Path) -> None:
     fake_file = tmp_path / "nonexistent.py"
     sections = build_sections({fake_file: [1, 2]})
-    out = format_human(
-        sections,
+    meta = OutputMeta(
         context_lines=0,
         with_code=False,
         coverage_xml=tmp_path / "cov.xml",
         color=True,
     )
+    out = format_human(sections, meta)
     assert "Uncovered sections in" in out
     assert "Line" in out
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,47 +1,72 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from showcov.core import build_sections
-from showcov.output import FORMATTERS, format_human, format_markdown, format_sarif
+from showcov.output import (
+    FORMATTERS,
+    Format,
+    OutputMeta,
+    format_human,
+    format_markdown,
+    format_sarif,
+    get_formatter,
+)
 
 
 def test_format_human_respects_color(tmp_path: Path) -> None:
     src = tmp_path / "x.py"
     src.write_text("a\n")
     sections = build_sections({src: [1]})
-    colored = format_human(
-        sections,
+    colored_meta = OutputMeta(
         context_lines=0,
         with_code=False,
         coverage_xml=tmp_path / "cov.xml",
         color=True,
     )
-    plain = format_human(
-        sections,
+    plain_meta = OutputMeta(
         context_lines=0,
         with_code=False,
         coverage_xml=tmp_path / "cov.xml",
         color=False,
     )
+    colored = format_human(sections, colored_meta)
+    plain = format_human(sections, plain_meta)
     assert "\x1b" in colored
     assert "\x1b" not in plain
 
 
 def test_format_registry() -> None:
-    assert set(FORMATTERS) == {"human", "json", "markdown", "sarif"}
+    assert set(FORMATTERS) == {
+        Format.HUMAN,
+        Format.JSON,
+        Format.MARKDOWN,
+        Format.SARIF,
+    }
+
+
+def test_format_from_str() -> None:
+    assert Format.from_str("json") is Format.JSON
+    with pytest.raises(ValueError, match="Unsupported format"):
+        Format.from_str("bogus")
+
+
+def test_get_formatter_enum() -> None:
+    assert get_formatter(Format.HUMAN) is FORMATTERS[Format.HUMAN]
 
 
 def test_format_markdown(tmp_path: Path) -> None:
     src = tmp_path / "x.py"
     src.write_text("a\n")
     sections = build_sections({src: [1]})
-    out = format_markdown(
-        sections,
+    meta = OutputMeta(
         context_lines=0,
         with_code=False,
         coverage_xml=tmp_path / "cov.xml",
         color=False,
     )
+    out = format_markdown(sections, meta)
     assert "<details>" in out
     assert "```" in out
 
@@ -50,13 +75,13 @@ def test_format_sarif(tmp_path: Path) -> None:
     src = tmp_path / "x.py"
     src.write_text("a\n")
     sections = build_sections({src: [1]})
-    out = format_sarif(
-        sections,
+    meta = OutputMeta(
         context_lines=0,
         with_code=False,
         coverage_xml=tmp_path / "cov.xml",
         color=False,
     )
+    out = format_sarif(sections, meta)
     data = json.loads(out)
     assert data["version"] == "2.1.0"
     assert data["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]["startLine"] == 1

--- a/tests/test_round_trip.py
+++ b/tests/test_round_trip.py
@@ -4,20 +4,20 @@ from typing import cast
 import pytest
 
 from showcov.core import UncoveredSection, build_sections
-from showcov.output import FORMATTERS, parse_json_output
+from showcov.output import FORMATTERS, Format, OutputMeta, parse_json_output
 
 
 def test_json_round_trip(tmp_path: Path) -> None:
     src = tmp_path / "x.py"
     src.write_text("a\nb\n")
     sections = build_sections({src: [1, 2]})
-    json_out = FORMATTERS["json"](
-        sections,
+    meta = OutputMeta(
         context_lines=1,
         with_code=True,
         coverage_xml=tmp_path / "cov.xml",
         color=False,
     )
+    json_out = FORMATTERS[Format.JSON](sections, meta)
     parsed = parse_json_output(json_out)
     assert parsed == sections
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 from showcov.core import build_sections
-from showcov.output import FORMATTERS
+from showcov.output import FORMATTERS, Format, OutputMeta
 
 
 def _build_sections() -> list:
@@ -12,13 +12,13 @@ def _build_sections() -> list:
 
 def test_json_output_snapshot() -> None:
     sections = _build_sections()
-    json_out = FORMATTERS["json"](
-        sections,
+    meta = OutputMeta(
         context_lines=1,
         with_code=True,
         coverage_xml=Path("coverage.xml"),
         color=False,
     )
+    json_out = FORMATTERS[Format.JSON](sections, meta)
     expected_text = Path("tests/snapshots/json_output.json").read_text(encoding="utf-8")
     actual = json.loads(json_out)
     expected = json.loads(expected_text)
@@ -31,13 +31,13 @@ def test_json_output_snapshot() -> None:
 
 def test_llm_prompt_snapshot() -> None:
     sections = _build_sections()
-    json_out = FORMATTERS["json"](
-        sections,
+    meta = OutputMeta(
         context_lines=1,
         with_code=True,
         coverage_xml=Path("coverage.xml"),
         color=False,
     )
+    json_out = FORMATTERS[Format.JSON](sections, meta)
     data = json.loads(json_out)
     data["version"] = "IGNORED"
     prompt = (


### PR DESCRIPTION
## Summary
- replace string formatter flags with `Format` enum and central registry
- consolidate formatter parameters into new `OutputMeta` dataclass
- update CLI, docs, and tests for new formatter API

## Testing
- `.venv/bin/ruff format src/ tests/`
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eb8be4b74832787ce5ee3d74d3f1d