### PR TITLE
feat: add model context protocol interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.0.18] - 2025-08-04
+
+### Added
+- add model context protocol interface and LLM payload generator
+- move output rendering logic to output package
+
+---
+
 ## [0.0.17] - 2025-08-04
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -1,21 +1,21 @@
-* [ ] refactor: move `render_output()` from `cli/util.py` to `output/`
-  * [ ] Preserve existing call site in CLI
-  * [ ] Ensure no CLI-specific logic remains in the moved function
+* [x] refactor: move `render_output()` from `cli/util.py` to `output/`
+  * [x] Preserve existing call site in CLI
+  * [x] Ensure no CLI-specific logic remains in the moved function
 
-* [ ] feature: implement model context protocol interface
-  * [ ] Add `mcp/` interface module under `src/showcov/mcp/`
-  * [ ] Define public function `get_model_context(sections: list[UncoveredSection], meta: OutputMeta) -> dict`
-    * [ ] Include version, environment metadata, uncovered sections (as JSON-compatible structures)
-    * [ ] Strip non-relevant fields and internal-only attributes
+* [x] feature: implement model context protocol interface
+  * [x] Add `mcp/` interface module under `src/showcov/mcp/`
+  * [x] Define public function `get_model_context(sections: list[UncoveredSection], meta: OutputMeta) -> dict`
+    * [x] Include version, environment metadata, uncovered sections (as JSON-compatible structures)
+    * [x] Strip non-relevant fields and internal-only attributes
 
-* [ ] feature: generate MCP JSON schema
-  * [ ] Expose function `generate_llm_payload(...) -> str`
-  * [ ] Ensure output adheres strictly to `mcp_schema.json`
-  * [ ] Validate output format under test using `jsonschema`
+* [x] feature: generate MCP JSON schema
+  * [x] Expose function `generate_llm_payload(...) -> str`
+  * [x] Ensure output adheres strictly to `mcp_schema.json`
+  * [x] Validate output format under test using `jsonschema`
 
-* [ ] test: add snapshot tests for model protocol
-  * [ ] Emit deterministic LLM payloads in `tests/snapshots/llm_interaction.json`
-  * [ ] Validate round-trip structure using `UncoveredSection.from_dict`
+* [x] test: add snapshot tests for model protocol
+  * [x] Emit deterministic LLM payloads in `tests/snapshots/llm_interaction.json`
+  * [x] Validate round-trip structure using `UncoveredSection.from_dict`
 
-* [ ] test: verify model output excludes global state
-  * [ ] Ensure only minimal interface-relevant state is present
+* [x] test: verify model output excludes global state
+  * [x] Ensure only minimal interface-relevant state is present

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "showcov"
-  version = "0.0.17"
+version = "0.0.18"
   description = "Print out uncovered code."
   readme = "README.md"
   authors = [

--- a/src/showcov/cli/entry.py
+++ b/src/showcov/cli/entry.py
@@ -24,13 +24,14 @@ from showcov.cli.util import (
     _emit_manpage,
     determine_format,
     parse_flags_to_opts,
-    render_output,
     resolve_sections,
     write_output,
 )
 from showcov.core import (
     CoverageXMLNotFoundError,
 )
+from showcov.output import render_output
+from showcov.output.base import OutputMeta
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
@@ -193,5 +194,16 @@ def show(
 
     is_tty = sys.stdout.isatty()
     actual_format = determine_format(opts, output, is_tty=is_tty)
-    output_text = render_output(sections, opts, actual_format, resolved_xml)
+    meta = OutputMeta(
+        context_lines=max(opts.context_before, opts.context_after),
+        with_code=opts.show_code,
+        coverage_xml=resolved_xml,
+        color=opts.use_color,
+    )
+    output_text = render_output(
+        sections,
+        actual_format,
+        meta,
+        aggregate_stats=opts.aggregate_stats,
+    )
     write_output(output_text, opts)

--- a/src/showcov/cli/util.py
+++ b/src/showcov/cli/util.py
@@ -23,12 +23,8 @@ from showcov.core import (
     determine_xml_file,
     gather_uncovered_lines_from_xml,
 )
-from showcov.output import (
-    get_formatter,
-)
 from showcov.output.base import (
     Format,
-    OutputMeta,
 )
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -171,38 +167,6 @@ def determine_format(opts: ShowcovOptions, output: Path | None, *, is_tty: bool)
         logger.info("destination: %s", output or "stdout")
 
     return fmt
-
-
-def render_output(
-    sections: list[UncoveredSection],
-    opts: ShowcovOptions,
-    fmt: Format,
-    xml_path: Path,
-) -> str:
-    if not sections:
-        return "No uncovered lines found (0 files matched input patterns)"
-
-    formatter = get_formatter(fmt)
-    meta = OutputMeta(
-        context_lines=max(opts.context_before, opts.context_after),
-        with_code=opts.show_code,
-        coverage_xml=xml_path,
-        color=opts.use_color,
-    )
-    output = formatter(sections, meta)
-
-    if opts.aggregate_stats and fmt is Format.HUMAN:
-        total_files = len(sections)
-        total_regions = sum(len(sec.ranges) for sec in sections)
-        total_lines = sum(end - start + 1 for sec in sections for start, end in sec.ranges)
-        footer = ", ".join([
-            f"{total_files} files with uncovered lines",
-            f"{total_regions} uncovered regions",
-            f"{total_lines} total lines",
-        ])
-        output = f"{output}\n{footer}"
-
-    return output
 
 
 def write_output(output_text: str, opts: ShowcovOptions) -> None:

--- a/src/showcov/data/mcp_schema.json
+++ b/src/showcov/data/mcp_schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/showcov.mcp.schema.json",
+  "title": "Showcov Model Context",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "environment": {
+      "type": "object",
+      "properties": {
+        "coverage_xml": {"type": "string"},
+        "context_lines": {"type": "integer", "minimum": 0},
+        "with_code": {"type": "boolean"}
+      },
+      "required": ["coverage_xml", "context_lines", "with_code"],
+      "additionalProperties": false
+    },
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": {"type": "string"},
+          "uncovered": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "start": {"type": "integer", "minimum": 1},
+                "end": {"type": "integer", "minimum": 1},
+                "source": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "line": {"type": "integer", "minimum": 1},
+                      "code": {"type": "string"}
+                    },
+                    "required": ["line", "code"],
+                    "additionalProperties": false
+                  },
+                  "minItems": 1
+                }
+              },
+              "required": ["start", "end"],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": ["file", "uncovered"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["version", "environment", "sections"],
+  "additionalProperties": false
+}

--- a/src/showcov/mcp/__init__.py
+++ b/src/showcov/mcp/__init__.py
@@ -1,0 +1,52 @@
+"""Model Context Protocol helpers."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from jsonschema import validate
+
+from showcov import __version__
+
+if TYPE_CHECKING:  # pragma: no cover
+    from showcov.core import UncoveredSection
+    from showcov.output.base import OutputMeta
+
+
+def _get_schema() -> dict[str, object]:
+    """Return the JSON schema for MCP payloads."""
+    text = resources.files("showcov.data").joinpath("mcp_schema.json").read_text(encoding="utf-8")
+    return json.loads(text)
+
+
+def get_model_context(sections: list[UncoveredSection], meta: OutputMeta) -> dict:
+    """Return a dictionary describing *sections* for LLM consumption."""
+    context_lines = max(0, meta.context_lines)
+    root = Path.cwd().resolve()
+    try:
+        xml_path = meta.coverage_xml.resolve().relative_to(root)
+    except ValueError:
+        xml_path = meta.coverage_xml.resolve()
+    data: dict[str, object] = {
+        "version": __version__,
+        "environment": {
+            "coverage_xml": xml_path.as_posix(),
+            "context_lines": context_lines,
+            "with_code": meta.with_code,
+        },
+        "sections": [sec.to_dict(with_code=meta.with_code, context_lines=context_lines) for sec in sections],
+    }
+    return data
+
+
+def generate_llm_payload(sections: list[UncoveredSection], meta: OutputMeta) -> str:
+    """Return JSON payload for LLMs, validated against the MCP schema."""
+    data = get_model_context(sections, meta)
+    validate(data, _get_schema())
+    return json.dumps(data, indent=2, sort_keys=True)
+
+
+__all__ = ["generate_llm_payload", "get_model_context"]

--- a/src/showcov/output/__init__.py
+++ b/src/showcov/output/__init__.py
@@ -7,6 +7,7 @@ from showcov.output.human import format_human
 from showcov.output.json import format_json
 from showcov.output.markdown import format_markdown
 from showcov.output.registry import FORMATTERS, get_formatter
+from showcov.output.render import render_output
 from showcov.output.sarif import format_sarif
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "format_markdown",
     "format_sarif",
     "get_formatter",
+    "render_output",
 ]

--- a/src/showcov/output/render.py
+++ b/src/showcov/output/render.py
@@ -1,0 +1,52 @@
+"""Utilities for rendering formatted output."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from showcov.output import get_formatter
+from showcov.output.base import Format, OutputMeta
+
+if TYPE_CHECKING:
+    from showcov.core import UncoveredSection
+
+
+def render_output(
+    sections: list[UncoveredSection],
+    fmt: Format,
+    meta: OutputMeta,
+    *,
+    aggregate_stats: bool = False,
+) -> str:
+    """Render ``sections`` according to ``fmt`` and ``meta``.
+
+    Parameters
+    ----------
+    sections:
+        Uncovered code sections to render.
+    fmt:
+        Desired output format.
+    meta:
+        Formatting metadata, such as context lines and colour options.
+    aggregate_stats:
+        When ``True`` and ``fmt`` is :class:`~showcov.output.base.Format.HUMAN`,
+        append a footer with aggregate statistics.
+    """
+    if not sections:
+        return "No uncovered lines found (0 files matched input patterns)"
+
+    formatter = get_formatter(fmt)
+    output = formatter(sections, meta)
+
+    if aggregate_stats and fmt is Format.HUMAN:
+        total_files = len(sections)
+        total_regions = sum(len(sec.ranges) for sec in sections)
+        total_lines = sum(end - start + 1 for sec in sections for start, end in sec.ranges)
+        footer = ", ".join([
+            f"{total_files} files with uncovered lines",
+            f"{total_regions} uncovered regions",
+            f"{total_lines} total lines",
+        ])
+        output = f"{output}\n{footer}"
+
+    return output

--- a/tests/snapshots/llm_interaction.json
+++ b/tests/snapshots/llm_interaction.json
@@ -1,0 +1,45 @@
+{
+  "environment": {
+    "context_lines": 1,
+    "coverage_xml": "coverage.xml",
+    "with_code": true
+  },
+  "sections": [
+    {
+      "file": "tests/data/sample.py",
+      "uncovered": [
+        {
+          "end": 5,
+          "source": [
+            {
+              "code": "def foo() -> None:",
+              "line": 1
+            },
+            {
+              "code": "    pass",
+              "line": 2
+            },
+            {
+              "code": "",
+              "line": 3
+            },
+            {
+              "code": "",
+              "line": 4
+            },
+            {
+              "code": "def bar() -> int:",
+              "line": 5
+            },
+            {
+              "code": "    return 42",
+              "line": 6
+            }
+          ],
+          "start": 2
+        }
+      ]
+    }
+  ],
+  "version": "0.0.18"
+}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from jsonschema import validate
+
+from showcov.core import UncoveredSection, build_sections
+from showcov.mcp import generate_llm_payload, get_model_context
+from showcov.output.base import OutputMeta
+
+
+def _sections() -> list[UncoveredSection]:
+    src = Path("tests/data/sample.py")
+    return build_sections({src: [2, 4, 5]})
+
+
+def _meta() -> OutputMeta:
+    return OutputMeta(
+        context_lines=1,
+        with_code=True,
+        coverage_xml=Path("coverage.xml"),
+        color=False,
+    )
+
+
+def test_llm_payload_snapshot() -> None:
+    sections = _sections()
+    payload = generate_llm_payload(sections, _meta())
+    expected = Path("tests/snapshots/llm_interaction.json").read_text(encoding="utf-8")
+    actual_data = json.loads(payload)
+    expected_data = json.loads(expected)
+    actual_data["version"] = "IGNORED"
+    expected_data["version"] = "IGNORED"
+    assert actual_data == expected_data
+
+
+def test_round_trip_and_schema_validation() -> None:
+    sections = _sections()
+    payload = generate_llm_payload(sections, _meta())
+    data = json.loads(payload)
+    schema = json.loads(Path("src/showcov/data/mcp_schema.json").read_text(encoding="utf-8"))
+    validate(data, schema)
+    rebuilt = [UncoveredSection.from_dict(d) for d in data["sections"]]
+    assert [(s.file.resolve(), s.ranges) for s in rebuilt] == [(s.file.resolve(), s.ranges) for s in sections]
+
+
+def test_model_context_minimal_state() -> None:
+    ctx = get_model_context(_sections(), _meta())
+    assert set(ctx.keys()) == {"version", "environment", "sections"}
+    assert set(ctx["environment"].keys()) == {"coverage_xml", "context_lines", "with_code"}


### PR DESCRIPTION
## Summary
- move CLI rendering logic into dedicated output module
- introduce model context protocol helpers with JSON schema and payload generator
- cover MCP interface with schema-validated snapshot tests

## Testing
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d938dcf08327ac6dbb7296b6f71d