### PR TITLE
feat: add html output format and file summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [0.0.19] - 2025-08-04
+
+### Added
+- add HTML output format for static reports
+- add optional per-file coverage summary with uncovered percentages
+- dynamically derive CLI format choices from available formats
+
+---
+
 ## [0.0.18] - 2025-08-04
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,9 @@
-- [ ] add HTML output format
+- [x] add HTML output format
   - add `--format html` to produce static, readable reports.
   - useful for sharing in CI artifacts, dashboards, or offline review.
-- [ ] add per-file coverage summary (informational, not enforcement)
+- [x] add per-file coverage summary (informational, not enforcement)
   - optionally show total uncovered lines per file and percent uncovered.
-  - e.g. `--file-summary` → `foo.py: 12 uncovered (30%)`.
+  - implemented via `--file-stats` → `foo.py: 12 uncovered (30%)`.
 - [ ] add a `diff` subcommand for report comparison
   - implement a `showcov diff a.xml b.xml` command.
   - show new uncovered lines or resolved ones since a baseline.
@@ -21,7 +21,7 @@
 - [ ] consolidate cli entry points
   - `cli`, `__main__`, `entry.py`, `util.py` spread logic across multiple files.
   - could unify command registration and dispatch into fewer modules.
-- [ ] avoid hardcoded format lists
+- [x] avoid hardcoded format lists
   - currently, `click.choice(["auto", "human", ...])` duplicates logic in `format`.
   - dynamically generate from `format.__members__` to prevent drift.
 - [ ] avoid internal state in output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "showcov"
-version = "0.0.18"
+version = "0.0.19"
   description = "Print out uncovered code."
   readme = "README.md"
   authors = [

--- a/src/showcov/__init__.py
+++ b/src/showcov/__init__.py
@@ -1,9 +1,12 @@
 import logging
+from importlib import import_module
 from importlib.metadata import version
 
 __version__ = version("showcov")
 
 logger = logging.getLogger(__name__)
 
+cli = import_module("showcov.cli")
+core = import_module("showcov.core")
 
-__all__ = ["__version__", "logger"]
+__all__ = ["__version__", "cli", "core", "logger"]

--- a/src/showcov/cli/entry.py
+++ b/src/showcov/cli/entry.py
@@ -31,7 +31,7 @@ from showcov.core import (
     CoverageXMLNotFoundError,
 )
 from showcov.output import render_output
-from showcov.output.base import OutputMeta
+from showcov.output.base import Format, OutputMeta
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
@@ -121,7 +121,7 @@ def completion(shell: str) -> None:
     "format_",
     default="auto",
     show_default=True,
-    type=click.Choice(["auto", "human", "json", "markdown", "sarif"], case_sensitive=False),
+    type=click.Choice([fmt.value for fmt in Format], case_sensitive=False),
     help="Output format",
 )
 @click.option("--pager", is_flag=True, help="Force paging even if stdout is redirected")
@@ -205,6 +205,7 @@ def show(
         actual_format,
         meta,
         aggregate_stats=opts.aggregate_stats,
+        file_stats=opts.file_stats,
     )
     write_output(output_text, opts)
 

--- a/src/showcov/mcp/models.py
+++ b/src/showcov/mcp/models.py
@@ -7,7 +7,7 @@ information to generate accurate input/output schemas automatically.*
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, PositiveInt, conint, validator
+from pydantic import BaseModel, Field, PositiveInt, model_validator
 
 # --------------------------------------------------------------------------- #
 # Primitives                                                                  #
@@ -25,12 +25,12 @@ class UncoveredRange(BaseModel):
     source: list[SourceLine] | None = None
 
     # Ensure callers pass sensible data when reconstructing from JSON
-    @validator("end")
-    def _end_not_before_start(cls, v: int, values):  # noqa: N805
-        if "start" in values and v < values["start"]:
+    @model_validator(mode="after")
+    def _end_not_before_start(self) -> UncoveredRange:
+        if self.end < self.start:
             msg = "end must be ≥ start"
             raise ValueError(msg)
-        return v
+        return self
 
 
 class CoverageFile(BaseModel):
@@ -45,7 +45,7 @@ class CoverageFile(BaseModel):
 
 class Environment(BaseModel):
     coverage_xml: str
-    context_lines: conint(ge=0, le=20)
+    context_lines: int = Field(ge=0, le=20)
     with_code: bool
 
 

--- a/src/showcov/output/__init__.py
+++ b/src/showcov/output/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from showcov.output.base import Format, Formatter
+from showcov.output.html import format_html
 from showcov.output.human import format_human
 from showcov.output.json import format_json
 from showcov.output.markdown import format_markdown
@@ -14,6 +15,7 @@ __all__ = [
     "FORMATTERS",
     "Format",
     "Formatter",
+    "format_html",
     "format_human",
     "format_json",
     "format_markdown",

--- a/src/showcov/output/base.py
+++ b/src/showcov/output/base.py
@@ -2,7 +2,7 @@
 
 Defines:
 
-- `Format`: Enum of supported output formats (human, json, markdown, sarif, auto).
+- `Format`: Enum of supported output formats (human, json, markdown, sarif, html, auto).
 - `OutputMeta`: Container for formatting options shared across all formatters.
 - `Formatter`: Protocol that all formatter functions must implement.
 
@@ -32,6 +32,7 @@ class Format(StrEnum):
     JSON = "json"
     MARKDOWN = "markdown"
     SARIF = "sarif"
+    HTML = "html"
     AUTO = "auto"
 
     @classmethod

--- a/src/showcov/output/html.py
+++ b/src/showcov/output/html.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from html import escape
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from showcov.core import UncoveredSection
+    from showcov.output.base import OutputMeta
+
+
+def format_html(sections: list[UncoveredSection], meta: OutputMeta) -> str:
+    """Return an HTML report for *sections*."""
+    context_lines = max(0, meta.context_lines)
+    root = Path.cwd().resolve()
+    parts: list[str] = ["<html>", "<body>"]
+    for section in sections:
+        try:
+            rel = section.file.resolve().relative_to(root)
+        except ValueError:
+            rel = section.file.resolve()
+        parts.append(f"<h2>{escape(rel.as_posix())}</h2>")
+        file_lines: list[str] = []
+        if meta.with_code:
+            try:
+                with section.file.open(encoding="utf-8") as f:
+                    file_lines = [ln.rstrip("\n") for ln in f.readlines()]
+            except OSError:
+                file_lines = []
+        for start, end in section.ranges:
+            header = f"Lines {start}-{end}" if start != end else f"Line {start}"
+            parts.append(f"<h3>{header}</h3>")
+            if meta.with_code and file_lines:
+                start_idx = max(1, start - context_lines)
+                end_idx = min(len(file_lines), end + context_lines)
+                snippet = []
+                for ln in range(start_idx, end_idx + 1):
+                    code = file_lines[ln - 1] if 1 <= ln <= len(file_lines) else "<line not found>"
+                    snippet.append(f"{ln}: {code}")
+                code_html = "<br/>".join(escape(line) for line in snippet)
+                parts.append(f"<pre>{code_html}</pre>")
+    parts.extend(("</body>", "</html>"))
+    return "\n".join(parts)

--- a/src/showcov/output/registry.py
+++ b/src/showcov/output/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from showcov.output.base import Format, Formatter
+from showcov.output.html import format_html
 from showcov.output.human import format_human
 from showcov.output.json import format_json
 from showcov.output.markdown import format_markdown
@@ -10,6 +11,7 @@ from showcov.output.sarif import format_sarif
 
 FORMATTERS: dict[Format, Formatter] = {
     Format.HUMAN: format_human,
+    Format.HTML: format_html,
     Format.JSON: format_json,
     Format.MARKDOWN: format_markdown,
     Format.SARIF: format_sarif,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,6 +130,23 @@ def test_cli_format_auto_json(
     assert out.lstrip().startswith("{")
 
 
+def test_cli_format_html(
+    cli_runner: CliRunner,
+    coverage_xml_file: Callable[..., Path],
+    tmp_path: Path,
+) -> None:
+    src = tmp_path / "f.py"
+    src.write_text("a\n")
+    xml = coverage_xml_file({src: [1]})
+
+    code, out = _run(
+        cli_runner,
+        ["show", "--cov", str(xml), str(src), "--format", "html"],
+    )
+    assert code == 0
+    assert out.lstrip().startswith("<html>")
+
+
 def test_cli_invalid_format_suggestion(
     cli_runner: CliRunner,
     coverage_xml_file: Callable[..., Path],


### PR DESCRIPTION
## Summary
- add `html` output format and dynamic CLI format choice
- show per-file uncovered line counts and percentages
- expose package submodules and fix lint/type issues

## Testing
- `ruff check src/ tests/`
- `ty check src/ tests/`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689109c3dbdc8327bc55e202345f1e6d