### PR TITLE
feat: render human output as rich table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.0.21] - 2025-08-04
+
+### Changed
+- render uncovered lines in rich table for human format
+
+---
+
 ## [0.0.20] - 2025-08-04
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 - [x] add a `diff` subcommand for report comparison
   - implement a `showcov diff a.xml b.xml` command.
   - show new uncovered lines or resolved ones since a baseline.
-- [ ] improve the `human` format with `rich` terminal table format
+- [x] improve the `human` format with `rich` terminal table format
   - display uncovered sections in a compact table format (`rich.table`).
   - columns: file | start line | end line | # lines
 - [ ] line-level tags / labels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # =================================== project ====================================
 [project]
   name = "showcov"
- version = "0.0.20"
+version = "0.0.21"
   description = "Print out uncovered code."
   readme = "README.md"
   authors = [

--- a/src/showcov/output/human.py
+++ b/src/showcov/output/human.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from rich.console import Console
-from rich.text import Text
+from rich.table import Table
 
 if TYPE_CHECKING:
     from showcov.core import UncoveredSection
@@ -15,34 +15,29 @@ if TYPE_CHECKING:
 
 
 def format_human(sections: list[UncoveredSection], meta: OutputMeta) -> str:
-    context_lines = max(0, meta.context_lines)
-
+    """Return uncovered sections in a simple table."""
     root = Path.cwd().resolve()
     console = Console(force_terminal=meta.color, width=sys.maxsize)
 
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("File", style="yellow")
+    table.add_column("Start", justify="right", style="cyan")
+    table.add_column("End", justify="right", style="cyan")
+    table.add_column("# Lines", justify="right", style="magenta")
+
+    for section in sections:
+        try:
+            rel = section.file.resolve().relative_to(root)
+        except ValueError:
+            rel = section.file.resolve()
+        for start, end in section.ranges:
+            table.add_row(
+                rel.as_posix(),
+                str(start),
+                str(end),
+                str(end - start + 1),
+            )
+
     with console.capture() as capture:
-        for section in sections:
-            try:
-                rel = section.file.resolve().relative_to(root)
-            except ValueError:
-                rel = section.file.resolve()
-            console.print(Text(f"Uncovered sections in {rel.as_posix()}:", style="bold yellow"))
-            try:
-                with section.file.open(encoding="utf-8") as f:
-                    file_lines = [ln.rstrip("\n") for ln in f.readlines()]
-            except OSError:
-                for start, end in section.ranges:
-                    line_str = f"Lines {start}-{end}" if start != end else f"Line {start}"
-                    console.print(Text(f"  {line_str}", style="cyan"))
-                continue
-            for start, end in section.ranges:
-                header = f"Lines {start}-{end}" if start != end else f"Line {start}"
-                console.print(Text(f"  {header}:", style="bold cyan"))
-                start_idx = max(1, start - context_lines)
-                end_idx = min(len(file_lines), end + context_lines)
-                for ln in range(start_idx, end_idx + 1):
-                    line_text = file_lines[ln - 1] if 1 <= ln <= len(file_lines) else "<line not found>"
-                    style = "magenta" if start <= ln <= end else ""
-                    console.print(f"    {ln:4d}: {line_text}", style=style)
-                console.print()
+        console.print(table)
     return capture.get()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -41,6 +41,24 @@ def test_format_human_respects_color(tmp_path: Path) -> None:
     assert "\x1b" not in plain
 
 
+def test_format_human_outputs_table(tmp_path: Path) -> None:
+    src = tmp_path / "x.py"
+    src.write_text("a\n" * 3)
+    sections = build_sections({src: [2, 3]})
+    meta = OutputMeta(
+        context_lines=0,
+        with_code=False,
+        coverage_xml=tmp_path / "cov.xml",
+        color=False,
+    )
+    out = format_human(sections, meta)
+    assert "File" in out
+    assert "Start" in out
+    assert "End" in out
+    assert "# Lines" in out
+    assert "x.py" in out
+
+
 def test_format_registry() -> None:
     assert set(FORMATTERS) == {
         Format.HUMAN,


### PR DESCRIPTION
## Summary
- render uncovered lines as a compact rich table in human output
- add tests for table output and adjust existing coverage tests
- bump version to 0.0.21

## Testing
- `.venv/bin/ruff format src/ tests/`
- `.venv/bin/ruff check src/ tests/`
- `.venv/bin/ty check src/ tests/`
- `.venv/bin/pytest`


------
https://chatgpt.com/codex/tasks/task_e_689117a8fa0c8327ae2278259956f1f1